### PR TITLE
Fix styled-components setup

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,31 @@
+import Document from "next/document";
+import { ServerStyleSheet } from "styled-components";
+import type { DocumentContext } from "next/document";
+
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) =>
+            sheet.collectStyles(<App {...props} />),
+        });
+
+      const initialProps = await Document.getInitialProps(ctx);
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } finally {
+      sheet.seal();
+    }
+  }
+}


### PR DESCRIPTION
According to [this commit](https://github.com/vercel/next.js/commit/7ce5d3f2408b08c6121b7edd825615161c616309) in the official Next.js styled-components app, we need to use the `_document` file to set up styled-components. Otherwise, there is aFOUC (Flash of unstyled content) on the initial request.