### PR TITLE
Cleanup CSS

### DIFF
--- a/features/ui/PageContainer/PageContainer.tsx
+++ b/features/ui/PageContainer/PageContainer.tsx
@@ -25,15 +25,14 @@ const Main = styled.main`
 `;
 
 const ContentContainer = styled.div`
-  min-height: calc(
-    100vh - 2 * ${space(8)} - ${({ theme }) => theme.size.headerHeight}
-  );
+  min-height: calc(100vh - ${({ theme }) => theme.size.headerHeight});
   margin-top: ${({ theme }) => theme.size.headerHeight};
   padding: ${space(8, 3)};
+  box-sizing: border-box;
   background: white;
 
   @media (min-width: ${breakpoint("desktop")}) {
-    min-height: calc(100vh - ${space(3)} - 2 * ${space(8)});
+    min-height: calc(100vh - ${space(3)});
     margin-top: ${space(3)};
     padding: ${space(8)};
     border-top-left-radius: ${space(10)};

--- a/features/ui/SidebarNavigation/SidebarNavigation.tsx
+++ b/features/ui/SidebarNavigation/SidebarNavigation.tsx
@@ -52,12 +52,13 @@ const FixedContainer = styled.div`
 `;
 
 const Header = styled.header`
-  width: calc(100% - 2 * ${space(4)});
+  width: 100%;
   height: ${({ theme }) => theme.size.headerHeight};
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: ${space(0, 4)};
+  box-sizing: border-box;
   background: ${color("gray", 900)};
   position: relative;
   z-index: ${zIndex("header")};
@@ -128,8 +129,9 @@ const Nav = styled.nav<{ isMobileMenuOpen: boolean }>`
   @media (min-width: ${breakpoint("desktop")}) {
     position: relative;
     top: 0;
-    width: calc(100% - ${space(8)});
+    width: 100%;
     padding: ${space(0, 4, 8)};
+    box-sizing: border-box;
     transform: none;
   }
 `;


### PR DESCRIPTION
Two components use an overcomplicated CSS calculation for their height or width. This PR refactors these by using `box-sizing: border-box`.