### PR TITLE
Fix cypress typescript setup

### DIFF
--- a/cypress/integration/issue-list.spec.ts
+++ b/cypress/integration/issue-list.spec.ts
@@ -82,5 +82,3 @@ describe("Project List", () => {
     });
   });
 });
-
-export {};

--- a/cypress/integration/navigation.spec.ts
+++ b/cypress/integration/navigation.spec.ts
@@ -68,5 +68,3 @@ describe("Sidebar Navigation", () => {
     });
   });
 });
-
-export {};

--- a/cypress/integration/project-list.spec.ts
+++ b/cypress/integration/project-list.spec.ts
@@ -32,5 +32,3 @@ describe("Project List", () => {
     });
   });
 });
-
-export {};

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
+    "isolatedModules": false,
     // be explicit about types included
     // to avoid clashing with Jest types
     "types": ["cypress", "@testing-library/cypress"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prolog-app",
-  "version": "0.1.0",
+  "version": "14.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/styles/theme.test.ts
+++ b/styles/theme.test.ts
@@ -66,5 +66,3 @@ describe("font utility functions", () => {
     expect(displayFontSmMd).toContain("font-weight: 500;");
   });
 });
-
-export {};


### PR DESCRIPTION
Allows non-isolated modules in TypeScript config for Cypress tests. This way there is no need for imports or empty export {} to pass type checks.